### PR TITLE
Fix title typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Awesome FMI [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
+# Awesome URDF [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
 
 > A curated list of Unified Robot Description Format (URDF) libraries, tools and resources. 
 


### PR DESCRIPTION
This PR fixes a typo in the readme I think it's a copy-paste from [here](https://github.com/traversaro/awesome-fmi)